### PR TITLE
Better plugin/server updating

### DIFF
--- a/contrib/utils.sh
+++ b/contrib/utils.sh
@@ -199,3 +199,15 @@ function download_latest_github_release() {
 	download_file "https://github.com/$repo/releases/download/$tag/$remote_file" \
 		"$output" "Could not download $remote_file from github repo $repo"
 }
+
+# $1: Feed URL
+# $2: json location
+# $3: output file name
+function download_from_json_feed() {
+	local download_url
+
+	download_url="$(curl -s -o - "$1" | jq -r "$2")" \
+			|| die "Error while retrieving url of type $2 from feed $1"
+
+	download_file "$download_url" "$3"
+}

--- a/contrib/utils.sh
+++ b/contrib/utils.sh
@@ -74,9 +74,10 @@ function download_file() {
 	domain=$(     echo "$1" | sed -E 's#^https?://([^/]+).*#\1#')
 	middle_path=$(echo "$1" | sed -E 's#^https?://[^/]+/##; s#/[^/]+$##')
 	last_part=$(  echo "$1" | sed -E 's#^.*/([^/?]+).*#\1#')
-	# where in the world is this file in the cache??????????
-	cache_path=$(realpath "$(dirname "${BASH_SOURCE[0]}")/..")
-	cache_path+="/cache/$domain/$middle_path/$last_part"
+
+	# where should the plugin file be stored?
+	cache_path=${XDG_DATA_HOME:-$HOME/.local/share}/minecraft-server/cache
+	cache_path+="/$domain/$middle_path/$last_part"
 	# is it not in cache?
 	if [[ ! -f "$cache_path" ]]; then
 		mkdir -p "$(dirname "$cache_path")" # just in case

--- a/contrib/utils.sh
+++ b/contrib/utils.sh
@@ -136,8 +136,8 @@ function download_velocity() {
 # $1: repo, e.g. "oddlama/vane"
 function latest_github_release_tag() {
 	local repo=$1
-	local cache=$(realpath "$(dirname "${BASH_SOURCE[0]}")/..")
-	cache+="/cache/github/$repo.txt"
+	local cache=${XDG_CACHE_HOME:-$HOME/.cache}/minecraft-server
+	cache+="/github/$repo.txt"
 	##### :( github rate limits suck!
 	##### thankfully, we can check if there were modifications
 	##### with the last_modified header, and it doesn't count

--- a/contrib/utils.sh
+++ b/contrib/utils.sh
@@ -91,12 +91,21 @@ function download_file() {
 }
 
 # $1: output file name
+# $2: OPTIONAL - paper minecraft version (eg. 1.20.4), if left empty
 function download_paper() {
 	local paper_version
 	local paper_build
 	local paper_download
-	paper_version="$(curl -s -o - "https://api.papermc.io/v2/projects/paper" | jq -r ".versions[-1]")" \
-		|| die "Error while retrieving paper version"
+	if [ $# -eq 0 ]; then
+		die "Not enough arguments passed to download_paper"
+	elif [ $# -eq 1 ]; then
+		paper_version="$(curl -s -o - "https://api.papermc.io/v2/projects/paper" | jq -r ".versions[-1]")" \
+			|| die "Error while retrieving latest paper version"
+	elif [ $# -eq 2 ]; then
+		paper_version="$2"
+	elif [ $# -gt 2 ]; then
+		die "Too many arguments passed to download_paper"
+	fi
 	paper_build="$(curl -s -o - "https://api.papermc.io/v2/projects/paper/versions/$paper_version" | jq -r ".builds[-1]")" \
 		|| die "Error while retrieving paper builds"
 	paper_download="$(curl -s -o - "https://api.papermc.io/v2/projects/paper/versions/$paper_version/builds/$paper_build" | jq -r ".downloads.application.name")" \

--- a/contrib/utils.sh
+++ b/contrib/utils.sh
@@ -125,16 +125,55 @@ function download_velocity() {
 }
 
 # $1: repo, e.g. "oddlama/vane"
-declare -A LATEST_GITHUB_RELEASE_TAG_CACHE
 function latest_github_release_tag() {
 	local repo=$1
-	if [[ ! -v "LATEST_GITHUB_RELEASE_TAG_CACHE[$repo]" ]]; then
-		local tmp
-		tmp=$(curl -s "https://api.github.com/repos/$repo/releases/latest" | jq -r .tag_name) \
-			|| die "Error while retrieving latest github release tag of $repo"
-		LATEST_GITHUB_RELEASE_TAG_CACHE[$repo]="$tmp"
+	local cache=$(realpath "$(dirname "${BASH_SOURCE[0]}")/..")
+	cache+="/cache/github/$repo.txt"
+	##### :( github rate limits suck!
+	##### thankfully, we can check if there were modifications
+	##### with the last_modified header, and it doesn't count
+	##### towards the limit
+	## stored in files named cache/github/user_name/repo_name.txt
+	## cache format:
+	## line #1: version info
+	## line #2: latest time checked
+	local last_modified
+	# first, check if cache file exists
+	if [[ -f "$cache" ]]; then
+		# if it does, great! we can store it into last_modified
+		last_modified=$(cat "$cache" | tail -n 1)
+	else
+		# I wonder, did the internet exist in times of Christ?
+		last_modified='Sun, 25 Dec 0000 07:18:26 GMT'
 	fi
-	echo "${LATEST_GITHUB_RELEASE_TAG_CACHE[$repo]}"
+
+	# send the request
+	local response=$(curl -i -s "https://api.github.com/repos/$repo/releases/latest" \
+		--include --header "if-modified-since: $last_modified")
+	local response_code=$(echo "$response" | head -n 1 | sed 's/^[^ ]* //')
+	# echos the response, sed only the headers, grep the header we want, and extract the contents with sed once more. Beautiful!
+	local response_last_modified=$(echo "$response" | sed '/^\r$/q' | grep 'last-modified: ' | sed 's/^[^:]*: //')
+	local response_requests_left=$(echo "$response" | sed '/^\r$/q' | grep 'x-ratelimit-remaining: ' | sed 's/^[^:]*: //')
+	local response_body=$(echo "$response" | sed '1,/^\r$/d')
+
+	if [[ "$response_requests_left" == "0" || ( "$response_code" == "403" || "$response_code" == "429" ) ]]; then
+		die 'Exceeded Github ratelimit, try again later'
+	elif [[ "$last_modified" == "$response_last_modified" && "$response_body" == "" ]]; then
+		# wasn't modified, we can use cache
+		cat "$cache" | head -n 1
+	elif [[ "$last_modified" != "$response_last_modified" && "$response_body" != "" ]]; then
+		# was modified, need to overwrite cache
+		local tag=$(echo "$response_body" | jq -r '.tag_name')
+		mkdir -p "$(dirname "$cache")"
+		if [[ "$tag" == "null" || "$response_last_modified" == "" ]]; then
+			die 'Incorrect tags, have you hit a ratelimit?'
+		fi
+		echo "$tag" > "$cache"
+		echo "$response_last_modified" >> "$cache"
+		echo "$tag"
+	else
+		die "Unreachable in latest_github_release_tag"
+	fi
 }
 
 # $1: repo, e.g. "oddlama/vane"
@@ -152,6 +191,10 @@ function download_latest_github_release() {
 
 	remote_file="${remote_file//"{TAG}"/"$tag"}"
 	remote_file="${remote_file//"{VERSION}"/"$version"}"
+
+	if [[ "$tag" == "" ]]; then
+		die "Tag fetching failed for $remote_file in $repo"
+	fi
 
 	download_file "https://github.com/$repo/releases/download/$tag/$remote_file" \
 		"$output" "Could not download $remote_file from github repo $repo"

--- a/contrib/utils.sh
+++ b/contrib/utils.sh
@@ -103,9 +103,8 @@ function download_paper() {
 		|| die "Error while retrieving paper download name"
 
 	substatus "Downloading paper version $paper_version build $paper_build ($paper_download)"
-	wget -q --show-progress "https://api.papermc.io/v2/projects/paper/versions/$paper_version/builds/$paper_build/downloads/$paper_download" \
-		-O "$1" \
-		|| die "Could not download paper"
+	download_file "https://api.papermc.io/v2/projects/paper/versions/$paper_version/builds/$paper_build/downloads/$paper_download" \
+		"$1" "Could not download paper"
 }
 
 # $1: output file name
@@ -121,9 +120,8 @@ function download_velocity() {
 		|| die "Error while retrieving velocity download name"
 
 	substatus "Downloading velocity version $velocity_version build $velocity_build ($velocity_download)"
-	wget -q --show-progress "https://api.papermc.io/v2/projects/velocity/versions/$velocity_version/builds/$velocity_build/downloads/$velocity_download" \
-		-O "$1" \
-		|| die "Could not download velocity"
+	download_file "https://api.papermc.io/v2/projects/velocity/versions/$velocity_version/builds/$velocity_build/downloads/$velocity_download" \
+		"$1" "Could not download velocity"
 }
 
 # $1: repo, e.g. "oddlama/vane"
@@ -155,6 +153,6 @@ function download_latest_github_release() {
 	remote_file="${remote_file//"{TAG}"/"$tag"}"
 	remote_file="${remote_file//"{VERSION}"/"$version"}"
 
-	wget -q --show-progress "https://github.com/$repo/releases/download/$tag/$remote_file" -O "$output" \
-		|| die "Could not download $remote_file from github repo $repo"
+	download_file "https://github.com/$repo/releases/download/$tag/$remote_file" \
+		"$output" "Could not download $remote_file from github repo $repo"
 }

--- a/proxy/update.sh
+++ b/proxy/update.sh
@@ -19,6 +19,15 @@ mkdir -p plugins \
 
 ################################################################
 # Download plugins
+# Can use the following util functions to add plugins to the autoupdater:
+# syntax: command (required argument) [optional argument]
+# - download_file (url) (output file) [failure message]
+# - download_latest_github_release (repo) (remote filename) (output file)
+#  -> {TAG} will be replaced with the release tag
+#  -> {VERSION} will be replaced with release tag excluding a leading v, if present
+# - download_from_json_feed (feed url) (jq parser) (output file)
+# - download_from_hangar (project) (platform) (output file)
+# - download_from_modrinth (mod ID/name) (platform) (output file) [minecraft version]
 
 substatus "Downloading plugins"
 download_latest_github_release "oddlama/vane" "vane-velocity-{VERSION}.jar" "plugins/vane-velocity.jar"

--- a/server/update.sh
+++ b/server/update.sh
@@ -22,6 +22,15 @@ mkdir -p plugins/optional \
 
 ################################################################
 # Download plugins
+# Can use the following util functions to add plugins to the autoupdater:
+# syntax: command (required argument) [optional argument]
+# - download_file (url) (output file) [failure message]
+# - download_latest_github_release (repo) (remote filename) (output file)
+#  -> {TAG} will be replaced with the release tag
+#  -> {VERSION} will be replaced with release tag excluding a leading v, if present
+# - download_from_json_feed (feed url) (jq parser) (output file)
+# - download_from_hangar (project) (platform) (output file)
+# - download_from_modrinth (mod ID/name) (platform) (output file) [minecraft version]
 
 substatus "Downloading plugins"
 for module in admin bedtime core enchantments permissions portals regions trifles; do


### PR DESCRIPTION
These series of commits add caching github tags to save ratelimits, downloading from a json feed, [Hangar](https://hangar.papermc.io/), and caching plugin files through the revamped download_file. Also allows a user to specify what minecraft version to update to through an optional argument in download_paper.