### PR TITLE
Copy installer bootstrap from pages branch to main branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,14 +31,14 @@ Afterwards you can continue [configuring your server](#Server-Configuration),
 or jump straight to the [Usage](#Usage) section if you are happy with the defaults.
 
 ```bash
-curl -sL https://oddlama.github.io/minecraft-server/bootstrap | sudo bash
+curl -sL https://github.com/oddlama/minecraft-server/raw/refs/heads/main/installer/bootstrap | sudo bash
 # Connect to the console (Press Ctrl+b then d to detach again)
 sudo minecraft-attach server
 # Don't forget to foward or expose TCP ports 25565 (server), 25566 (multiplexer 1)
 # and 8100 (online map). The map will be available under http://<your-ip>:8100
 ```
 
-You may want to [review](https://github.com/oddlama/minecraft-server/blob/pages/docs/bootstrap) the script before executing it.
+You may want to [review](https://github.com/oddlama/minecraft-server/blob/main/installer/bootstrap) the script before executing it.
 In summary, the script will perform the following steps:
 
 - Check whether all required tools are installed

--- a/installer/bootstrap
+++ b/installer/bootstrap
@@ -1,0 +1,232 @@
+#!/bin/bash
+
+set -uo pipefail
+
+umask 077
+TTY="/dev/$(ps -p $$ -o tty=)"
+
+################################################################
+# Helper functions
+
+function die() { echo "[1;31merror:[m $*" >&2; exit 1; }
+function status() { echo "${had_status+$'\n'}[1;33m$*[m"; had_status=1; }
+function flush_stdin() { while read -r -t 0.01 empty_stdin < "$TTY"; do true; done; }
+function ask() {
+	local response
+	while true; do
+		flush_stdin
+		read -r -p "$* (Y/n) " response < "$TTY" || die "Error in read"
+		case "${response,,}" in
+			'') return 0 ;;
+			y|yes) return 0 ;;
+			n|no) return 1 ;;
+			*) continue ;;
+		esac
+	done
+}
+# $1 = src, $2 = dest, $3 = owner, $4 = mode
+function install_file() {
+	cp    "$1" "$2" || die "Could not copy '$1' to '$2'"
+	chown "$3" "$2" || die "Could not chown '$2'"
+	chmod "$4" "$2" || die "Could not chmod '$2'"
+}
+
+################################################################
+# Ensure that all required tools are installed
+
+abort=0
+for i in jq git tmux rdiff-backup java openssl; do
+	if ! type "$i" &>/dev/null; then
+		echo "[1;31mmissing: [1;33m$i[m" >&2
+		abort=1
+	fi
+done
+
+[[ "$abort" == "0" ]] \
+	|| die "Please install the missing tools first."
+
+
+################################################################
+# Ensure memory requirements are met and we have root access
+
+total_ram_gibi=$(free -g | grep -oP '\d+' | head -n1)
+if [[ $total_ram_gibi -le 4 ]]; then
+	echo "[31mYour system has [33m${total_ram_gibi}GiB[31m of RAM, which probably is not enough to run minecraft"
+	echo "without issues. The recommended minimum amount is _at least_ [33m12GiB[31m.[m"
+	ask "Continue anyway?" || die "Installation aborted."
+	echo
+elif [[ $total_ram_gibi -lt 12 ]]; then
+	echo "[31mYour system has [33m${total_ram_gibi}GiB[31m of RAM, which less than the recommended amount of"
+	echo "_at least_ [33m12GiB[31m. This will hurt the server performance significantly.[m"
+	ask "Continue anyway?" || die "Installation aborted."
+	echo
+fi
+
+[[ $EUID == 0 ]] || die "Must be root for system-wide installation."
+
+
+################################################################
+# Ensure EULA is accepted
+
+status "Agree to Mojang EULA"
+echo "You have to agree to Mojang's EULA to use the server software."
+echo "It is available here: https://account.mojang.com/documents/minecraft_eula"
+ask "Do you agree to the EULA?" \
+	|| die "Installation aborted. EULA must be accepted to continue."
+
+
+################################################################
+# Create minecraft user if necessary
+
+if ! getent passwd minecraft &>/dev/null; then
+	status "Creating minecraft user"
+	useradd --system --home-dir /var/lib/minecraft --no-create-home minecraft \
+		|| die "Could not create user 'minecraft'"
+fi
+
+mkdir -p /var/lib/minecraft
+chmod 700 /var/lib/minecraft
+chown minecraft: /var/lib/minecraft
+
+
+################################################################
+# Setup repository
+
+if [[ -e /var/lib/minecraft/deploy ]]; then
+	echo "[33mThe deploy directory /var/lib/minecraft/deploy already exists."
+	echo "You can still run the installer again, but it may overwrite some"
+	echo "configuration files if you edited them in the meantime.[m"
+	ask "Are you sure you want to continue?" \
+		|| die "Installation aborted."
+fi
+
+cd /var/lib/minecraft \
+	|| die "Could not change into /var/lib/minecraft"
+
+if [[ -e deploy ]]; then
+	status "Updating deploy repository"
+	runuser -u minecraft -- git -C deploy pull \
+		|| die "Could not pull repository"
+else
+	status "Cloning deploy repository"
+	runuser -u minecraft -- git clone "https://github.com/oddlama/minecraft-server" deploy \
+		|| die "Could not clone repository"
+fi
+
+cd deploy \
+	|| die "Could not change into deploy directory"
+
+status "Configuring server"
+install_file <(echo "eula=true") server/eula.txt minecraft: 600
+
+for d in $(find contrib/default_config -type d -printf '%P\n'); do
+	mkdir -p -m700 "$d" || die "Could not create directory '$d'"
+	chown minecraft: "$d" || die "Could not chown directory '$d'"
+done
+
+for f in $(find contrib/default_config -type f -printf '%P\n'); do
+	install_file contrib/default_config/"$f" "$f" minecraft: 600
+done
+
+VELOCITYSECRET=$(openssl rand -base64 16) \
+	|| die "Could not generate velocity secret"
+install_file <(echo -n "$VELOCITYSECRET") proxy/forwarding.secret minecraft: 600
+sed -i 's|{{VELOCITYSECRET}}|'"$VELOCITYSECRET"'|' server/config/paper-global.yml \
+	|| die "Could not insert velocity secret in paper-global.yml"
+
+echo "Depending on your player base, you might want to allow certain gamplay"
+echo "exploits on your server. These are fixed by default in PaperMC, but would"
+echo "allow your players to build certain vanilla machines (TNT blast chambers,"
+echo "bedrock removal, ...). My personal recommendation is to answer with yes"
+echo "to all of these questions."
+echo
+
+if ask "Allow headless pistons and bedrock breaking?"; then
+	sed -i 's|allow-headless-pistons: false|allow-headless-pistons: true|' server/config/paper-global.yml \
+		|| die "Could not replace allow-headless-pistons config"
+	sed -i 's|allow-permanent-block-break-exploits: false|allow-permanent-block-break-exploits: true|' server/config/paper-global.yml \
+		|| die "Could not replace allow-permanent-block-break-exploits config"
+fi
+
+if ask "Allow piston TNT duping?"; then
+	sed -i 's|allow-piston-duplication: false|allow-piston-duplication: true|' server/config/paper-global.yml \
+		|| die "Could not replace allow-piston-duplication config"
+fi
+
+if ask "Enable Anti-XRAY?"; then
+	sed -i 's|false # ANTI_XRAY|true|' server/config/paper-world-defaults.yml \
+		|| die "Could not replace ANTI_XRAY config"
+else
+	sed -i 's|false # ANTI_XRAY|false|' server/config/paper-world-defaults.yml \
+		|| die "Could not replace ANTI_XRAY config"
+fi
+
+if ask "Replenish loot in loot chests after 1-2 realtime days?"; then
+	sed -i 's|auto-replenish: false|auto-replenish: true|' server/config/paper-world-defaults.yml \
+		|| die "Could not replace auto-replenish config"
+fi
+
+if ask "Disable hopper item move event to reduce lag?"; then
+	sed -i 's|disable-move-event: false|disable-move-event: true|' server/config/paper-world-defaults.yml \
+		|| die "Could not replace disable-move-event config"
+fi
+
+if ask "Increase view-distance to 15 chunks?"; then
+	sed -i 's|view-distance=10|view-distance=15|' server/server.properties \
+		|| die "Could not replace view-distance config"
+fi
+
+echo
+runuser -u minecraft -- ./update.sh < "$TTY" \
+	|| die "Could not update server files"
+
+
+################################################################
+# Install systemd services
+
+status "Installing service files"
+./contrib/install.sh < "$TTY" \
+	|| die "Error while installing service files"
+
+
+################################################################
+# Enable and start services
+
+status "Starting services ..."
+echo "[33mSystem services for the proxy and server will now be enabled and started."
+echo "If you want to adjust any proxy related configuration, you may want to start"
+echo "them manually later.[m"
+echo
+
+postponed_service_message=""
+if ask "Enable and start system services now?"; then
+	systemctl enable --now minecraft-server minecraft-proxy < "$TTY" \
+		|| die "Error while enabling services"
+else
+	postponed_service_message="
+You have postponed enabling the system services. Make sure to execute the
+following command when you are ready to start the server:
+
+[1;32m    systemctl enable --now minecraft-server minecraft-proxy[m
+"
+fi
+
+
+################################################################
+# Success message
+
+cat <<EOF
+[1m================================================================================[m
+                            [1;32mInstallation successful![m
+[1m================================================================================[m
+The server and proxy have been installed successfully! The PaperMC minecraft
+server will be started when a player connects via the proxy. Be aware that the
+first start may take a while due to world generation.
+
+Please make sure that TCP port [35m25565[m (server), [35m25566[m (multiplex 1) and [35m8100[m
+(bluemap webserver) are exposed to the internet via a port-foward or similar
+mechanism. If you want to change your server configuration, please do so now.
+$postponed_service_message
+For more information, visit [35mhttps://github.com/oddlama/minecraft-server[m
+[1m================================================================================[m
+EOF


### PR DESCRIPTION
### The current issue
Currently, the bootstrap installer is stored in the `pages` branch. While this is well and good for hosting the installer somewhere, right now any change to the server that changes the directory structure or some config file locations even slightly will inevitably result in having to submit two PRs, one for the config file change in main, and another to alter the bootstrapper to adapt such a change into the installation project.

This can be a problem if someone runs the bootstrap installer while only one of the PRs have been merged, because then some commands on the bootstrapper will assume that is there when it really is.

### Proposed solution
Moving the bootstrap install to the main branch will allow one PR to update both files. To do this, a sequence of migration steps can be made:

1. Merge this PR, copying the current bootstrap file into the main branch (inside a new folder named `installer`, that we _could_ handle within the bootstrapper later)
2. Later on the pages branch, changing the shell command to the raw url on the main branch eg. `https://raw.githubusercontent.com/oddlama/minecraft-server/refs/heads/bootstrap-migration/installer/bootstrap`
3. We can then delete the old `bootstrap` installer on the pages branch to remove duplicated code... even in the same PR.
4. From now on, instead of having to maintain two PRs for improving an aspect of the mc server, simply do it all in one PR.

I'll try to add a draft PR to the `pages` branch implementing steps 2-3, which ill mark as "ready for review" when/if this PR gets accepted.

And, as always, please suggest any changes if you think something needs improvement!