### PR TITLE
Update utils.sh

### DIFF
--- a/contrib/utils.sh
+++ b/contrib/utils.sh
@@ -82,7 +82,7 @@ function download_file() {
 	if [[ ! -f "$cache_path" ]]; then
 		mkdir -p "$(dirname "$cache_path")" # just in case
 		# fetch it
-		wget -L -q --show-progress "$1" -O "$cache_path" || die "$failure_message"
+		wget -q --show-progress "$1" -O "$cache_path" || die "$failure_message"
 	else
 		touch -c -a "$cache_path"
 	fi


### PR DESCRIPTION
Remove -L from wget since it doesn't work in certain cases (or at all anymore, not sure).
The -L makes it so that the installer doesn't work (at least under Fedora 42 Server that I tested on)
I tested it without -L on a Fedora 42 Server Virtual Machine and the installer works now